### PR TITLE
Add arm64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Lowercase repository
         id: repo


### PR DESCRIPTION
- Builds images for amd64 and arm64
- As well as tagging the new image as latest, it will also tag it with the latest git tag used